### PR TITLE
Add multi-page site with consistent layout and SEO metadata

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import Navbar from "../../components/Navbar";
+import Footer from "../../components/Footer";
+import { Container, SectionTitle, Card } from "../../components/ui";
+
+export const metadata: Metadata = {
+  title: "Blog – Editra",
+  description: "Novinky a články o postprodukci, VFX a technologii.",
+};
+
+export default function BlogPage() {
+  return (
+    <div className="min-h-screen text-slate-100" id="top">
+      <Navbar />
+      <main>
+        <section className="pt-6">
+          <Container className="py-14">
+            <SectionTitle level="h1" title="Blog" subtitle="Novinky a postřehy z postprodukce a VFX" />
+            <Card>
+              <p className="text-sm text-slate-300">Zatím zde nejsou žádné články. Sledujte nás pro aktuality.</p>
+            </Card>
+          </Container>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/app/kontakt/page.tsx
+++ b/app/kontakt/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import Navbar from "../../components/Navbar";
+import Footer from "../../components/Footer";
+import ContactSection from "../../components/ContactSection";
+
+export const metadata: Metadata = {
+  title: "Kontakt – Editra",
+  description:
+    "Pojďme probrat váš projekt. E-mail, telefon a adresa studia Editra.",
+};
+
+export default function ContactPage() {
+  return (
+    <div className="min-h-screen text-slate-100" id="top">
+      <Navbar />
+      <main>
+        <ContactSection level="h1" />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/app/o-nas/page.tsx
+++ b/app/o-nas/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import Navbar from "../../components/Navbar";
+import Footer from "../../components/Footer";
+import AboutSection from "../../components/AboutSection";
+
+export const metadata: Metadata = {
+  title: "O nás – Editra",
+  description:
+    "Kreativci s inženýrskou disciplínou. Sídlíme v Plzni.",
+};
+
+export default function AboutPage() {
+  return (
+    <div className="min-h-screen text-slate-100" id="top">
+      <Navbar />
+      <main>
+        <AboutSection level="h1" />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,126 +1,28 @@
 "use client";
 import { motion } from "framer-motion";
 import {
-  Film,
-  Wand2,
-  Cpu,
   Workflow,
   GaugeCircle,
   ShieldCheck,
+  Cpu,
   PlayCircle,
-  CheckCircle2,
-  Mail,
-  Phone,
-  MapPin,
   ArrowRight,
+  CheckCircle2,
 } from "lucide-react";
+import Navbar from "../components/Navbar";
+import Footer from "../components/Footer";
+import {
+  Container,
+  SectionTitle,
+  Card,
+  Badge,
+  Button,
+} from "../components/ui";
+import ServicesSection from "../components/ServicesSection";
+import PortfolioSection from "../components/PortfolioSection";
+import AboutSection from "../components/AboutSection";
+import ContactSection from "../components/ContactSection";
 
-
-// --- Simple UI primitives (Tailwind-based, no external UI lib needed) ---
-import React, { ReactNode } from "react";
-
-const Container = ({
-  children,
-  className = "",
-}: { children: ReactNode; className?: string }) => (
-  <div className={`mx-auto w-full max-w-7xl px-6 lg:px-8 ${className}`}>{children}</div>
-);
-
-type SectionTitleProps = {
-  eyebrow?: React.ReactNode;
-  title: React.ReactNode;
-  subtitle?: React.ReactNode;
-};
-
-const SectionTitle = ({ eyebrow, title, subtitle }: SectionTitleProps) => (
-  <div className="mx-auto mb-10 max-w-3xl text-center">
-    {eyebrow && (
-      <p className="mb-2 text-sm font-semibold uppercase tracking-widest text-sky-400">
-        {eyebrow}
-      </p>
-    )}
-    <h2 className="text-3xl font-semibold leading-tight text-white sm:text-4xl">
-      {title}
-    </h2>
-    {subtitle && (
-      <p className="mt-3 text-base text-slate-300">{subtitle}</p>
-    )}
-  </div>
-);
-
-const Card = ({
-  children,
-  className = "",
-}: { children: React.ReactNode; className?: string }) => (
-  <div className={`group relative overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-6 shadow-[0_0_0_1px_rgba(255,255,255,0.06)] backdrop-blur transition hover:shadow-sky-500/10 ${className}`}>
-    <div className="pointer-events-none absolute inset-0 rounded-2xl bg-gradient-to-br from-white/5 to-transparent opacity-0 transition group-hover:opacity-100" />
-    {children}
-  </div>
-);
-
-const Badge = ({ children }: { children: React.ReactNode }) => (
-  <span className="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-slate-200">
-    {children}
-  </span>
-);
-
-type ButtonProps = {
-  children: React.ReactNode;
-  href?: string;
-  variant?: "primary" | "ghost";
-  className?: string;
-  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
-};
-
-const Button = ({
-  children,
-  href = "#",
-  variant = "primary",
-  className = "",
-  onClick,
-}: ButtonProps) => {
-  const base =
-    "inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-sky-400/60";
-  const styles = {
-    primary:
-      "bg-sky-500 text-white hover:bg-sky-400 active:bg-sky-600 shadow-lg shadow-sky-500/20",
-    ghost:
-      "border border-white/15 bg-white/5 text-white hover:border-white/25",
-  };
-  return (
-    <a href={href} className={`${base} ${styles[variant]} ${className}`} onClick={onClick}>
-      {children}
-    </a>
-  );
-};
-
-
-
-// --- Navbar ---
-const Navbar = () => (
-  <header className="sticky top-0 z-40 backdrop-blur supports-[backdrop-filter]:bg-slate-950/60">
-    <Container className="flex items-center justify-between py-4">
-      <a href="#top" className="flex items-center gap-2 text-white">
-        <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-sky-500/90 shadow-lg shadow-sky-500/30">
-          <Film className="h-5 w-5" />
-        </div>
-        <span className="text-lg font-bold tracking-wide">Editra</span>
-      </a>
-      <nav className="hidden items-center gap-6 text-sm text-slate-200 md:flex">
-        <a href="#domu" className="hover:text-white">Domů</a>
-        <a href="#sluzby" className="hover:text-white">Služby</a>
-        <a href="#portfolio" className="hover:text-white">Portfolio</a>
-        <a href="#onas" className="hover:text-white">O nás</a>
-        <a href="#kontakt" className="hover:text-white">Kontakt</a>
-      </nav>
-      <div className="hidden md:block">
-        <Button href="#kontakt">Nezávazná poptávka</Button>
-      </div>
-    </Container>
-  </header>
-);
-
-// --- Hero ---
 const Hero = () => (
   <section id="top" className="relative overflow-hidden">
     <Container className="py-20 sm:py-28">
@@ -140,7 +42,7 @@ const Hero = () => (
             transition={{ delay: 0.1, duration: 0.6 }}
             className="mt-5 max-w-xl text-base text-slate-300 sm:text-lg"
           >
-            Jsme studio <strong>Editra</strong>. Color grading a VFX přidáme podle potřeby. 
+            Jsme studio <strong>Editra</strong>. Color grading a VFX přidáme podle potřeby.
             Čisté výstupy pro TV, online i kino – rychle a spolehlivě. To vše pod záštitou našeho
             <strong> automatizovaného QC Enginu.</strong>
           </motion.p>
@@ -150,7 +52,7 @@ const Hero = () => (
             transition={{ delay: 0.2, duration: 0.6 }}
             className="mt-8 flex flex-wrap gap-3"
           >
-            <Button href="#kontakt">
+            <Button href="/kontakt">
               Domluvme si schůzku <ArrowRight className="h-4 w-4" />
             </Button>
             <Button href="https://www.youtube.com/embed/P-m6gLofH-Q" variant="ghost">
@@ -170,7 +72,7 @@ const Hero = () => (
           transition={{ delay: 0.15, duration: 0.6 }}
           className="relative"
         >
-            <div className="relative aspect-[16/10] w-full overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-slate-800 to-slate-900 shadow-2xl">
+          <div className="relative aspect-[16/10] w-full overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-slate-800 to-slate-900 shadow-2xl">
             <iframe
               className="absolute inset-0 h-full w-full"
               src="https://www.youtube.com/embed/P-m6gLofH-Q"
@@ -178,24 +80,39 @@ const Hero = () => (
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowFullScreen
             />
-            </div>
-            <p className="mt-4 text-center text-sm text-slate-400">VFX prvky pro Unexpected Visuals</p>
+          </div>
+          <p className="mt-4 text-center text-sm text-slate-400">VFX prvky pro Unexpected Visuals</p>
         </motion.div>
       </div>
     </Container>
   </section>
 );
 
-// --- Stats / Value Props ---
 const ValueProps = () => (
   <section>
     <Container className="py-10">
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {[
-          { icon: <Workflow className="h-5 w-5" />, title: "End‑to‑End pipeline", text: "Ingest → VFX → Color → QC → Delivery" },
-          { icon: <GaugeCircle className="h-5 w-5" />, title: "Rychlost & škálování", text: "Batch procesy, render farmy, skriptování" },
-          { icon: <ShieldCheck className="h-5 w-5" />, title: "Bezchybné výstupy", text: "Automatizované testy, loudness, titulky, safe‑margins" },
-          { icon: <Cpu className="h-5 w-5" />, title: "Data‑driven", text: "Analytika, metriky, reporting pro klienty" },
+          {
+            icon: <Workflow className="h-5 w-5" />,
+            title: "End‑to‑End pipeline",
+            text: "Ingest → VFX → Color → QC → Delivery",
+          },
+          {
+            icon: <GaugeCircle className="h-5 w-5" />,
+            title: "Rychlost & škálování",
+            text: "Batch procesy, render farmy, skriptování",
+          },
+          {
+            icon: <ShieldCheck className="h-5 w-5" />,
+            title: "Bezchybné výstupy",
+            text: "Automatizované testy, loudness, titulky, safe‑margins",
+          },
+          {
+            icon: <Cpu className="h-5 w-5" />,
+            title: "Data‑driven",
+            text: "Analytika, metriky, reporting pro klienty",
+          },
         ].map((v, i) => (
           <Card key={i} className="flex items-start gap-4">
             <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white/5">
@@ -212,107 +129,6 @@ const ValueProps = () => (
   </section>
 );
 
-// --- Services ---
-const Services = () => (
-  <section id="sluzby" className="pt-6">
-    <Container className="py-14">
-      <SectionTitle
-        eyebrow="Služby"
-        title="Co pro vás uděláme"
-        subtitle="Od prvního záběru po finální master. Vše pod jednou střechou – kreativně i technicky."
-      />
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-         <Card>
-          <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-sky-500/20">
-              <Film className="h-5 w-5 text-sky-300" />
-            </div>
-            <h3 className="text-lg font-semibold text-white">Postprodukce</h3>
-          </div>
-          <p className="mt-2 text-sm text-slate-300">
-            Offline/online střih, color grading, mastering a příprava dodávek pro TV/online/kino.
-          </p>
-          <div className="mt-4 flex flex-wrap gap-2">
-            <Badge>Premiere Pro</Badge><Badge>DaVinci Resolve</Badge><Badge>ProRes / IMF</Badge>
-          </div>
-        </Card>
-        <Card>
-          <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-sky-500/20">
-              <Wand2 className="h-5 w-5 text-sky-300" />
-            </div>
-            <h3 className="text-lg font-semibold text-white">VFX & Compositing</h3>
-          </div>
-          <p className="mt-2 text-sm text-slate-300">
-            2D/3D compositing, clean‑up, keying, tracking, retuše, matchmove a FX simulace.
-          </p>
-          <div className="mt-4 flex flex-wrap gap-2">
-            <Badge>Nuke</Badge><Badge>After Effects</Badge><Badge>Mocha</Badge>
-          </div>
-        </Card>
-        <Card>
-          <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-sky-500/20">
-              <Cpu className="h-5 w-5 text-sky-300" />
-            </div>
-            <h3 className="text-lg font-semibold text-white">Color grading & finishing</h3>
-          </div>
-          <p className="mt-2 text-sm text-slate-300">
-            Tvoříme skripty a nástroje: ingest, transkódování, verze, kontrola hlasitosti, kontrola titulků, QC reporty.
-          </p>
-          <div className="mt-4 flex flex-wrap gap-2">
-            <Badge>Python</Badge><Badge>FFmpeg</Badge><Badge>OCR</Badge><Badge>API</Badge>
-          </div>
-        </Card>
-      </div>
-    </Container>
-  </section>
-);
-
-
-
-// --- Portfolio / Showreel ---
-const Portfolio = () => (
-  <section id="portfolio" className="">
-    <Container className="py-14">
-      <SectionTitle
-        eyebrow="Portfolio"
-        title="Showreel a ukázky"
-        subtitle="Krátké ukázky naší práce. Plnou knihovnu rádi nasdílíme při callu."
-      />
-      <div className="grid gap-6 lg:grid-cols-2">
-        <Card>
-          <div className="aspect-video w-full overflow-hidden rounded-xl">
-            <iframe
-              className="h-full w-full"
-              src="https://www.youtube.com/embed/LolmAiyCg2c"
-              title="Case study"
-              allow="autoplay; fullscreen; picture-in-picture"
-              allowFullScreen
-            />
-          </div>
-          <h3 className="mt-4 text-base font-semibold text-white">Summer City Fest Plzeň 2024</h3>
-          <p className="mt-1 text-sm text-slate-300">Postprodukce aftermovie.</p>
-        </Card>
-        <Card>
-          <div className="aspect-video w-full overflow-hidden rounded-xl">
-            <iframe
-              className="h-full w-full"
-              src="https://www.youtube.com/embed/opazwv2YkPs"
-              title="Case study"
-              allow="autoplay; fullscreen; picture-in-picture"
-              allowFullScreen
-            />
-          </div>
-          <h3 className="mt-4 text-base font-semibold text-white">DOTS - Broken Skies</h3>
-          <p className="mt-1 text-sm text-slate-300">Postprodukce, color grading videoklipu</p>
-        </Card>
-      </div>
-    </Container>
-  </section>
-);
-
-// --- Pipeline ---
 const Pipeline = () => (
   <section id="pipeline" className="">
     <Container className="py-14">
@@ -323,12 +139,36 @@ const Pipeline = () => (
       />
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         {[
-          { step: "01", title: "Ingest & Metadata", text: "Bezpečný import, kontrola framerate/codec, automatické rozpoznání parametrů." },
-          { step: "02", title: "Edit / Conform", text: "Proxy, EDL/XML/AAF, synchronizace zvuku a časových kódů." },
-          { step: "03", title: "VFX / Comp", text: "Shot breakdown, verzování, trackování tasků a schvalování." },
-          { step: "04", title: "Color & Finishing", text: "Color science, LUT management, exporty pro mastering." },
-          { step: "05", title: "Automatizované QC", text: "Loudness (EBU R128), gamut, titulky, safe‑area, artefakty, drop‑frames." },
-          { step: "06", title: "Delivery & Archiving", text: "Dodávky pro TV, VOD, kino, archivace s checksumy (MD5/XXH)." },
+          {
+            step: "01",
+            title: "Ingest & Metadata",
+            text: "Bezpečný import, kontrola framerate/codec, automatické rozpoznání parametrů.",
+          },
+          {
+            step: "02",
+            title: "Edit / Conform",
+            text: "Proxy, EDL/XML/AAF, synchronizace zvuku a časových kódů.",
+          },
+          {
+            step: "03",
+            title: "VFX / Comp",
+            text: "Shot breakdown, verzování, trackování tasků a schvalování.",
+          },
+          {
+            step: "04",
+            title: "Color & Finishing",
+            text: "Color science, LUT management, exporty pro mastering.",
+          },
+          {
+            step: "05",
+            title: "Automatizované QC",
+            text: "Loudness (EBU R128), gamut, titulky, safe‑area, artefakty, drop‑frames.",
+          },
+          {
+            step: "06",
+            title: "Delivery & Archiving",
+            text: "Dodávky pro TV, VOD, kino, archivace s checksumy (MD5/XXH).",
+          },
         ].map((item, i) => (
           <Card key={i}>
             <div className="flex items-center justify-between">
@@ -344,151 +184,18 @@ const Pipeline = () => (
   </section>
 );
 
-// --- About ---
-const About = () => (
-  <section id="onas">
-    <Container className="py-14">
-      <SectionTitle
-        eyebrow="O nás"
-        title="Kreativci s inženýrskou disciplínou"
-        subtitle="Sídlíme v Plzni. Spojujeme filmové řemeslo s automatizací a daty – abychom doručili víc kvality za kratší čas."
-      />
-      <div className="grid gap-6 lg:grid-cols-2">
-        <Card>
-          <h3 className="text-base font-semibold text-white">Proč Editra</h3>
-          <p className="mt-2 text-sm text-slate-300">
-            Každý projekt bereme jako systém: jasná pipeline, měřitelné metriky a
-            přehledná komunikace. Díky vlastním nástrojům minimalizujeme lidské chyby a 
-            máme kontrolu nad kvalitou v každém kroku.
-          </p>
-          <div className="mt-4 flex flex-wrap gap-2">
-            <Badge>Versioning</Badge><Badge>Render queue</Badge><Badge>QC gates</Badge><Badge>Reporting</Badge>
-          </div>
-        </Card>
-        <Card>
-          <h3 className="text-base font-semibold text-white">Technologie</h3>
-          <p className="mt-2 text-sm text-slate-300">
-            Pracujeme s nástroji jako Nuke, After Effects, DaVinci Resolve a Python/FFmpeg
-            skripty. Integrujeme OCR, kontrolu hlasitosti, validaci titulků a exportů.
-          </p>
-          <div className="mt-4 flex flex-wrap gap-2">
-            <Badge>Nuke</Badge><Badge>AE</Badge><Badge>Resolve</Badge><Badge>Python</Badge><Badge>FFmpeg</Badge>
-          </div>
-        </Card>
-      </div>
-    </Container>
-  </section>
-);
-
-// --- Contact ---
-const Contact = () => (
-  <section id="kontakt">
-    <Container className="py-14">
-      <SectionTitle
-        eyebrow="Kontakt"
-        title="Pojďme probrat váš projekt"
-        subtitle="Napište pár řádků o zakázce. Ozveme se během jednoho pracovního dne."
-      />
-      <div className="grid gap-8 lg:grid-cols-2">
-        <Card>
-          <form onSubmit={(e) => e.preventDefault()} className="space-y-4">
-            <div className="grid gap-4 sm:grid-cols-2">
-              <div>
-                <label className="mb-1 block text-xs font-medium text-slate-300">Jméno</label>
-                <input
-                  required
-                  placeholder="Jan Novák"
-                  className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-400/60"
-                />
-              </div>
-              <div>
-                <label className="mb-1 block text-xs font-medium text-slate-300">Email</label>
-                <input
-                  required
-                  type="email"
-                  placeholder="jan@example.com"
-                  className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-400/60"
-                />
-              </div>
-            </div>
-            <div>
-              <label className="mb-1 block text-xs font-medium text-slate-300">Předmět</label>
-              <input
-                placeholder="Téma / typ projektu"
-                className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-400/60"
-              />
-            </div>
-            <div>
-              <label className="mb-1 block text-xs font-medium text-slate-300">Zpráva</label>
-              <textarea
-                rows={5}
-                placeholder="Stručný popis, termín, rozpočet…"
-                className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-400/60"
-              />
-            </div>
-            <div className="flex items-center justify-between">
-              <div className="text-xs text-slate-400">Odesláním souhlasíte se zpracováním údajů pro účely poptávky.</div>
-              <Button href="#" onClick={(e) => e.preventDefault()}>
-                Odeslat poptávku
-              </Button>
-            </div>
-          </form>
-        </Card>
-        <div className="space-y-6">
-          <Card>
-            <h3 className="text-base font-semibold text-white">Kontakt</h3>
-            <div className="mt-3 space-y-2 text-sm text-slate-300">
-              <p className="flex items-center gap-2"><Mail className="h-4 w-4" /> hello@editra.cz</p>
-              <p className="flex items-center gap-2"><Phone className="h-4 w-4" /> +420 777 000 000</p>
-              <p className="flex items-center gap-2"><MapPin className="h-4 w-4" /> Plzeň, Česká republika</p>
-            </div>
-            <div className="mt-4 flex gap-2">
-              <Button variant="ghost" href="mailto:hello@editra.cz">Napsat email</Button>
-              <Button variant="ghost" href="tel:+420777000000">Zavolat</Button>
-            </div>
-          </Card>
-          <Card>
-            <div className="aspect-video w-full overflow-hidden rounded-xl">
-              <iframe
-                className="h-full w-full"
-                loading="lazy"
-                referrerPolicy="no-referrer-when-downgrade"
-                src="https://www.google.com/maps?q=Plze%C5%88&output=embed"
-                title="Mapa – Plzeň"
-              />
-            </div>
-          </Card>
-        </div>
-      </div>
-    </Container>
-  </section>
-);
-
-// --- Footer ---
-const Footer = () => (
-  <footer className="border-t border-white/10">
-    <Container className="flex flex-col items-center justify-between gap-4 py-8 text-sm text-slate-400 md:flex-row">
-      <p>© {new Date().getFullYear()} Editra – Postprodukční studio</p>
-      <div className="flex items-center gap-4">
-        <a href="#top" className="hover:text-white">Zpět nahoru</a>
-        <a href="#" className="hover:text-white">Zásady ochrany osobních údajů</a>
-      </div>
-    </Container>
-  </footer>
-);
-
 export default function EditraLandingPage() {
   return (
-    <div className="min-h-screen  text-slate-100">
+    <div className="min-h-screen text-slate-100">
       <Navbar />
       <main>
         <Hero />
         <ValueProps />
-        <Services />
-        <Portfolio />
+        <ServicesSection />
+        <PortfolioSection />
         <Pipeline />
-        <About />
-        <Contact />
+        <AboutSection />
+        <ContactSection />
       </main>
       <Footer />
     </div>

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import Navbar from "../../components/Navbar";
+import Footer from "../../components/Footer";
+import PortfolioSection from "../../components/PortfolioSection";
+
+export const metadata: Metadata = {
+  title: "Portfolio – Editra",
+  description: "Showreel a ukázky naší postprodukční práce.",
+};
+
+export default function PortfolioPage() {
+  return (
+    <div className="min-h-screen text-slate-100" id="top">
+      <Navbar />
+      <main>
+        <PortfolioSection level="h1" />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/app/sluzby/page.tsx
+++ b/app/sluzby/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import Navbar from "../../components/Navbar";
+import Footer from "../../components/Footer";
+import ServicesSection from "../../components/ServicesSection";
+
+export const metadata: Metadata = {
+  title: "Služby – Editra",
+  description:
+    "Postprodukce, VFX, color grading a automatizace v Editra.",
+};
+
+export default function ServicesPage() {
+  return (
+    <div className="min-h-screen text-slate-100" id="top">
+      <Navbar />
+      <main>
+        <ServicesSection level="h1" />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/components/AboutSection.tsx
+++ b/components/AboutSection.tsx
@@ -1,0 +1,47 @@
+import { Container, SectionTitle, Card, Badge, type HeadingLevel } from "./ui";
+
+interface Props {
+  level?: HeadingLevel;
+}
+
+const AboutSection = ({ level = "h2" }: Props) => (
+  <section>
+    <Container className="py-14">
+      <SectionTitle
+        eyebrow="O nás"
+        title="Kreativci s inženýrskou disciplínou"
+        subtitle="Sídlíme v Plzni. Spojujeme filmové řemeslo s automatizací a daty – abychom doručili víc kvality za kratší čas."
+        level={level}
+      />
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <h3 className="text-base font-semibold text-white">Proč Editra</h3>
+          <p className="mt-2 text-sm text-slate-300">
+            Každý projekt bereme jako systém: jasná pipeline, měřitelné metriky a přehledná komunikace. Díky vlastním nástrojům minimalizujeme lidské chyby a máme kontrolu nad kvalitou v každém kroku.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Badge>Versioning</Badge>
+            <Badge>Render queue</Badge>
+            <Badge>QC gates</Badge>
+            <Badge>Reporting</Badge>
+          </div>
+        </Card>
+        <Card>
+          <h3 className="text-base font-semibold text-white">Technologie</h3>
+          <p className="mt-2 text-sm text-slate-300">
+            Pracujeme s nástroji jako Nuke, After Effects, DaVinci Resolve a Python/FFmpeg skripty. Integrujeme OCR, kontrolu hlasitosti, validaci titulků a exportů.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Badge>Nuke</Badge>
+            <Badge>AE</Badge>
+            <Badge>Resolve</Badge>
+            <Badge>Python</Badge>
+            <Badge>FFmpeg</Badge>
+          </div>
+        </Card>
+      </div>
+    </Container>
+  </section>
+);
+
+export default AboutSection;

--- a/components/ContactSection.tsx
+++ b/components/ContactSection.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { Mail, Phone, MapPin } from "lucide-react";
+import { Container, SectionTitle, Card, Button, type HeadingLevel } from "./ui";
+
+interface Props {
+  level?: HeadingLevel;
+}
+
+const ContactSection = ({ level = "h2" }: Props) => (
+  <section>
+    <Container className="py-14">
+      <SectionTitle
+        eyebrow="Kontakt"
+        title="Pojďme probrat váš projekt"
+        subtitle="Napište pár řádků o zakázce. Ozveme se během jednoho pracovního dne."
+        level={level}
+      />
+      <div className="grid gap-8 lg:grid-cols-2">
+        <Card>
+          <form onSubmit={(e) => e.preventDefault()} className="space-y-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label className="mb-1 block text-xs font-medium text-slate-300">Jméno</label>
+                <input
+                  required
+                  placeholder="Jan Novák"
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-400/60"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-xs font-medium text-slate-300">Email</label>
+                <input
+                  required
+                  type="email"
+                  placeholder="jan@example.com"
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-400/60"
+                />
+              </div>
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-300">Předmět</label>
+              <input
+                placeholder="Téma / typ projektu"
+                className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-400/60"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-300">Zpráva</label>
+              <textarea
+                rows={5}
+                placeholder="Stručný popis, termín, rozpočet…"
+                className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-400/60"
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <div className="text-xs text-slate-400">Odesláním souhlasíte se zpracováním údajů pro účely poptávky.</div>
+              <Button href="#" onClick={(e) => e.preventDefault()}>
+                Odeslat poptávku
+              </Button>
+            </div>
+          </form>
+        </Card>
+        <div className="space-y-6">
+          <Card>
+            <h3 className="text-base font-semibold text-white">Kontakt</h3>
+            <div className="mt-3 space-y-2 text-sm text-slate-300">
+              <p className="flex items-center gap-2"><Mail className="h-4 w-4" /> hello@editra.cz</p>
+              <p className="flex items-center gap-2"><Phone className="h-4 w-4" /> +420 777 000 000</p>
+              <p className="flex items-center gap-2"><MapPin className="h-4 w-4" /> Plzeň, Česká republika</p>
+            </div>
+            <div className="mt-4 flex gap-2">
+              <Button variant="ghost" href="mailto:hello@editra.cz">Napsat email</Button>
+              <Button variant="ghost" href="tel:+420777000000">Zavolat</Button>
+            </div>
+          </Card>
+          <Card>
+            <div className="aspect-video w-full overflow-hidden rounded-xl">
+              <iframe
+                className="h-full w-full"
+                loading="lazy"
+                referrerPolicy="no-referrer-when-downgrade"
+                src="https://www.google.com/maps?q=Plze%C5%88&output=embed"
+                title="Mapa – Plzeň"
+              />
+            </div>
+          </Card>
+        </div>
+      </div>
+    </Container>
+  </section>
+);
+
+export default ContactSection;

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+import { Container } from "./ui";
+
+const Footer = () => (
+  <footer className="border-t border-white/10">
+    <Container className="flex flex-col items-center justify-between gap-4 py-8 text-sm text-slate-400 md:flex-row">
+      <p>© {new Date().getFullYear()} Editra – Postprodukční studio</p>
+      <div className="flex items-center gap-4">
+        <Link href="#top" className="hover:text-white">
+          Zpět nahoru
+        </Link>
+        <Link href="#" className="hover:text-white">
+          Zásady ochrany osobních údajů
+        </Link>
+      </div>
+    </Container>
+  </footer>
+);
+
+export default Footer;

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import { Film } from "lucide-react";
+import { Container, Button } from "./ui";
+
+const Navbar = () => (
+  <header className="sticky top-0 z-40 backdrop-blur supports-[backdrop-filter]:bg-slate-950/60">
+    <Container className="flex items-center justify-between py-4">
+      <Link href="/" className="flex items-center gap-2 text-white">
+        <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-sky-500/90 shadow-lg shadow-sky-500/30">
+          <Film className="h-5 w-5" />
+        </div>
+        <span className="text-lg font-bold tracking-wide">Editra</span>
+      </Link>
+      <nav className="hidden items-center gap-6 text-sm text-slate-200 md:flex">
+        <Link href="/" className="hover:text-white">Domů</Link>
+        <Link href="/sluzby" className="hover:text-white">Služby</Link>
+        <Link href="/portfolio" className="hover:text-white">Portfolio</Link>
+        <Link href="/blog" className="hover:text-white">Blog</Link>
+        <Link href="/o-nas" className="hover:text-white">O nás</Link>
+        <Link href="/kontakt" className="hover:text-white">Kontakt</Link>
+      </nav>
+      <div className="hidden md:block">
+        <Button href="/kontakt">Nezávazná poptávka</Button>
+      </div>
+    </Container>
+  </header>
+);
+
+export default Navbar;

--- a/components/PortfolioSection.tsx
+++ b/components/PortfolioSection.tsx
@@ -1,0 +1,48 @@
+import { Container, SectionTitle, Card, type HeadingLevel } from "./ui";
+
+interface Props {
+  level?: HeadingLevel;
+}
+
+const PortfolioSection = ({ level = "h2" }: Props) => (
+  <section>
+    <Container className="py-14">
+      <SectionTitle
+        eyebrow="Portfolio"
+        title="Showreel a ukázky"
+        subtitle="Krátké ukázky naší práce. Plnou knihovnu rádi nasdílíme při callu."
+        level={level}
+      />
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <div className="aspect-video w-full overflow-hidden rounded-xl">
+            <iframe
+              className="h-full w-full"
+              src="https://www.youtube.com/embed/LolmAiyCg2c"
+              title="Case study"
+              allow="autoplay; fullscreen; picture-in-picture"
+              allowFullScreen
+            />
+          </div>
+          <h3 className="mt-4 text-base font-semibold text-white">Summer City Fest Plzeň 2024</h3>
+          <p className="mt-1 text-sm text-slate-300">Postprodukce aftermovie.</p>
+        </Card>
+        <Card>
+          <div className="aspect-video w-full overflow-hidden rounded-xl">
+            <iframe
+              className="h-full w-full"
+              src="https://www.youtube.com/embed/opazwv2YkPs"
+              title="Case study"
+              allow="autoplay; fullscreen; picture-in-picture"
+              allowFullScreen
+            />
+          </div>
+          <h3 className="mt-4 text-base font-semibold text-white">DOTS - Broken Skies</h3>
+          <p className="mt-1 text-sm text-slate-300">Postprodukce, color grading videoklipu</p>
+        </Card>
+      </div>
+    </Container>
+  </section>
+);
+
+export default PortfolioSection;

--- a/components/ServicesSection.tsx
+++ b/components/ServicesSection.tsx
@@ -1,0 +1,72 @@
+import { Film, Wand2, Cpu } from "lucide-react";
+import { Container, SectionTitle, Card, Badge, type HeadingLevel } from "./ui";
+
+interface Props {
+  level?: HeadingLevel;
+}
+
+const ServicesSection = ({ level = "h2" }: Props) => (
+  <section className="pt-6">
+    <Container className="py-14">
+      <SectionTitle
+        eyebrow="Služby"
+        title="Co pro vás uděláme"
+        subtitle="Od prvního záběru po finální master. Vše pod jednou střechou – kreativně i technicky."
+        level={level}
+      />
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <Card>
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-sky-500/20">
+              <Film className="h-5 w-5 text-sky-300" />
+            </div>
+            <h3 className="text-lg font-semibold text-white">Postprodukce</h3>
+          </div>
+          <p className="mt-2 text-sm text-slate-300">
+            Offline/online střih, color grading, mastering a příprava dodávek pro TV/online/kino.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Badge>Premiere Pro</Badge>
+            <Badge>DaVinci Resolve</Badge>
+            <Badge>ProRes / IMF</Badge>
+          </div>
+        </Card>
+        <Card>
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-sky-500/20">
+              <Wand2 className="h-5 w-5 text-sky-300" />
+            </div>
+            <h3 className="text-lg font-semibold text-white">VFX & Compositing</h3>
+          </div>
+          <p className="mt-2 text-sm text-slate-300">
+            2D/3D compositing, clean‑up, keying, tracking, retuše, matchmove a FX simulace.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Badge>Nuke</Badge>
+            <Badge>After Effects</Badge>
+            <Badge>Mocha</Badge>
+          </div>
+        </Card>
+        <Card>
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-sky-500/20">
+              <Cpu className="h-5 w-5 text-sky-300" />
+            </div>
+            <h3 className="text-lg font-semibold text-white">Color grading & finishing</h3>
+          </div>
+          <p className="mt-2 text-sm text-slate-300">
+            Tvoříme skripty a nástroje: ingest, transkódování, verze, kontrola hlasitosti, kontrola titulků, QC reporty.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Badge>Python</Badge>
+            <Badge>FFmpeg</Badge>
+            <Badge>OCR</Badge>
+            <Badge>API</Badge>
+          </div>
+        </Card>
+      </div>
+    </Container>
+  </section>
+);
+
+export default ServicesSection;

--- a/components/ui.tsx
+++ b/components/ui.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+
+export type HeadingLevel = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+
+export const Container = ({
+  children,
+  className = "",
+}: { children: React.ReactNode; className?: string }) => (
+  <div className={`mx-auto w-full max-w-7xl px-6 lg:px-8 ${className}`}>{children}</div>
+);
+
+export type SectionTitleProps = {
+  eyebrow?: React.ReactNode;
+  title: React.ReactNode;
+  subtitle?: React.ReactNode;
+  level?: HeadingLevel;
+};
+
+export const SectionTitle = ({
+  eyebrow,
+  title,
+  subtitle,
+  level = "h2",
+}: SectionTitleProps) => {
+  const Heading = level as keyof JSX.IntrinsicElements;
+  return (
+    <div className="mx-auto mb-10 max-w-3xl text-center">
+      {eyebrow && (
+        <p className="mb-2 text-sm font-semibold uppercase tracking-widest text-sky-400">
+          {eyebrow}
+        </p>
+      )}
+      <Heading className="text-3xl font-semibold leading-tight text-white sm:text-4xl">
+        {title}
+      </Heading>
+      {subtitle && <p className="mt-3 text-base text-slate-300">{subtitle}</p>}
+    </div>
+  );
+};
+
+export const Card = ({
+  children,
+  className = "",
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) => (
+  <div className={`group relative overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-6 shadow-[0_0_0_1px_rgba(255,255,255,0.06)] backdrop-blur transition hover:shadow-sky-500/10 ${className}`}>
+    <div className="pointer-events-none absolute inset-0 rounded-2xl bg-gradient-to-br from-white/5 to-transparent opacity-0 transition group-hover:opacity-100" />
+    {children}
+  </div>
+);
+
+export const Badge = ({ children }: { children: React.ReactNode }) => (
+  <span className="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-slate-200">
+    {children}
+  </span>
+);
+
+export type ButtonProps = {
+  children: React.ReactNode;
+  href?: string;
+  variant?: "primary" | "ghost";
+  className?: string;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+};
+
+export const Button = ({
+  children,
+  href = "#",
+  variant = "primary",
+  className = "",
+  onClick,
+}: ButtonProps) => {
+  const base =
+    "inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-sky-400/60";
+  const styles = {
+    primary:
+      "bg-sky-500 text-white hover:bg-sky-400 active:bg-sky-600 shadow-lg shadow-sky-500/20",
+    ghost:
+      "border border-white/15 bg-white/5 text-white hover:border-white/25",
+  } as const;
+  return (
+    <a href={href} className={`${base} ${styles[variant]} ${className}`} onClick={onClick}>
+      {children}
+    </a>
+  );
+};


### PR DESCRIPTION
## Summary
- Add shared UI components, Navbar and Footer for cohesive design across pages
- Create dedicated pages for Služby, Portfolio, O nás, Kontakt and Blog with SEO metadata
- Refactor home page to reuse sections and link to new routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a867df0d388322a6aef002d4594e78